### PR TITLE
feat: update references from KLHK to MENLHK in Sidebar, AuthContext, …

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -47,7 +47,7 @@ const Sidebar: React.FC = () => {
         {!isCollapsed && (
           <div className="flex-1 min-w-0">
             <span className="text-base font-bold text-slate-800 block leading-tight">{t('common:app.name')}</span>
-            <span className="text-[10px] text-slate-500 block leading-tight">KLHK</span>
+            <span className="text-[10px] text-slate-500 block leading-tight">MENLHK</span>
           </div>
         )}
       </div>

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -29,7 +29,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const login = async (email: string, password: string): Promise<boolean> => {
     // Mock authentication - only works with specific credentials
-    if (email === 'admin@klhkproject.mail' && password === 'Admin12345') {
+    if (email === 'admin@menlhkproject.mail' && password === 'Admin12345') {
       const userData = {
         email: email,
         name: 'System Administrator'

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/klhk-logo-small.png" />
-    <title>TMAT Monitoring - KLHK</title>
+    <title>TMAT Monitoring - MENLHK</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -70,8 +70,8 @@ const Login: React.FC = () => {
             </h1>
             <p className="text-slate-700 font-semibold text-sm mb-1">
               {isIndonesian 
-                ? 'Kementerian Lingkungan Hidup dan Kehutanan' 
-                : 'Ministry of Environment and Forestry'}
+                ? 'Kementerian Lingkungan Hidup' 
+                : 'Ministry of Environment'}
             </p>
             <p className="text-slate-600 text-sm">
               {isIndonesian 
@@ -179,13 +179,13 @@ const Login: React.FC = () => {
                   <p className="text-xs text-slate-600">
                     <strong>{isIndonesian ? 'Email:' : 'Email:'}</strong>{' '}
                     <code className="bg-white px-2 py-0.5 rounded text-emerald-700 font-mono text-xs">
-                      admin@klhkproject.mail
+                      admin@menlhkproject.mail
                     </code>
                   </p>
                 </div>
                 <button
                   type="button"
-                  onClick={() => copyToClipboard('admin@klhkproject.mail', 'email')}
+                  onClick={() => copyToClipboard('admin@menlhkproject.mail', 'email')}
                   className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-emerald-700 bg-white hover:bg-emerald-50 border border-emerald-200 rounded transition-colors"
                   title={isIndonesian ? 'Salin email' : 'Copy email'}
                 >
@@ -237,8 +237,8 @@ const Login: React.FC = () => {
         {/* Footer */}
         <p className="text-center text-sm text-slate-500 mt-6">
           {isIndonesian 
-            ? '© 2025 Kementerian Lingkungan Hidup dan Kehutanan. Semua hak dilindungi.' 
-            : '© 2025 Ministry of Environment and Forestry. All rights reserved.'}
+            ? '© 2025 Kementerian Lingkungan Hidup. Semua hak dilindungi.' 
+            : '© 2025 Ministry of Environment. All rights reserved.'}
         </p>
       </div>
     </div>


### PR DESCRIPTION
This pull request updates the application to reflect a change in institutional branding, replacing references to "KLHK" (Kementerian Lingkungan Hidup dan Kehutanan / Ministry of Environment and Forestry) with "MENLHK" (Kementerian Lingkungan Hidup / Ministry of Environment). The changes affect UI labels, authentication credentials, and metadata, ensuring consistency throughout the app.

**Branding and Institutional Name Updates**

* Changed display name in the sidebar from "KLHK" to "MENLHK" (`components/Sidebar.tsx`).
* Updated the application title in `index.html` to "TMAT Monitoring - MENLHK".

**Authentication and Credentials**

* Updated the mock admin login credentials from `admin@klhkproject.mail` to `admin@menlhkproject.mail` in both the login form and authentication logic (`context/AuthContext.tsx`, `pages/Login.tsx`). [[1]](diffhunk://#diff-31e0d99088ce815f0879cbaf2e04df20c359c18a068c9579cfd1920d7d1b666aL32-R32) [[2]](diffhunk://#diff-bfb047d3adfea2fee9392dd2715c6022712a4a65458c6dc2521a8942468be848L182-R188)

**UI Text and Footer**

* Modified the institution name in the login page and footer to reflect "Kementerian Lingkungan Hidup" / "Ministry of Environment" instead of the previous longer form (`pages/Login.tsx`). [[1]](diffhunk://#diff-bfb047d3adfea2fee9392dd2715c6022712a4a65458c6dc2521a8942468be848L73-R74) [[2]](diffhunk://#diff-bfb047d3adfea2fee9392dd2715c6022712a4a65458c6dc2521a8942468be848L240-R241)…and Login components