### PR TITLE
feat: enhance DashboardMap component to display detailed device infor…

### DIFF
--- a/components/DashboardMap.tsx
+++ b/components/DashboardMap.tsx
@@ -890,7 +890,7 @@ const DashboardMap: React.FC<Props> = ({ devices, heightClass }) => {
               position={[firstDevice.latitude, firstDevice.longitude]} 
               icon={createWaterDropletIcon(mostCriticalColor, deviceCount)}
             >
-              {deviceCount > 1 && (
+              {deviceCount > 1 ? (
                 <Popup maxWidth={320} minWidth={280}>
                   <div className="p-2">
                     <h3 className="font-bold text-slate-800 text-sm mb-2">
@@ -925,6 +925,60 @@ const DashboardMap: React.FC<Props> = ({ devices, heightClass }) => {
                           </div>
                         );
                       })}
+                    </div>
+                  </div>
+                </Popup>
+              ) : (
+                <Popup maxWidth={320} minWidth={280}>
+                  <div className="p-3">
+                    <h3 className="font-bold text-slate-800 text-sm mb-1">
+                      {firstDevice.device_id_unik}
+                    </h3>
+                    <p className="text-xs text-slate-600 mb-3">
+                      {firstDevice.kota}, {firstDevice.provinsi}
+                    </p>
+                    
+                    <div className="mb-3 p-2 bg-emerald-50 rounded-lg border border-emerald-200">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-emerald-700">
+                          {isIndonesian ? 'Status' : 'Status'}
+                        </span>
+                        {deviceDataMap.has(firstDevice.device_id_unik) && (
+                          <span className="text-xs font-bold text-emerald-700">
+                            {getWaterLevelStatus(deviceDataMap.get(firstDevice.device_id_unik)?.tmat_value || 0).level}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      {deviceDataMap.has(firstDevice.device_id_unik) ? (
+                        <>
+                          <div className="flex items-center justify-between p-2 bg-slate-50 rounded">
+                            <span className="text-xs text-slate-600">
+                              {isIndonesian ? 'Nilai TMAT' : 'TMAT Value'}
+                            </span>
+                            <span className="text-xs font-bold text-slate-800">
+                              {deviceDataMap.get(firstDevice.device_id_unik)?.tmat_value.toFixed(2)} cm
+                            </span>
+                          </div>
+                          
+                          <div className="flex items-center justify-between p-2 bg-slate-50 rounded">
+                            <span className="text-xs text-slate-600">
+                              {isIndonesian ? 'Waktu Update' : 'Last Update'}
+                            </span>
+                            <span className="text-xs font-bold text-slate-800">
+                              {new Date(deviceDataMap.get(firstDevice.device_id_unik)?.timestamp || '').toLocaleTimeString()}
+                            </span>
+                          </div>
+                        </>
+                      ) : (
+                        <div className="p-2 bg-slate-50 rounded text-center">
+                          <p className="text-xs text-slate-500 italic">
+                            {isIndonesian ? 'Data tidak tersedia' : 'No data available'}
+                          </p>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </Popup>


### PR DESCRIPTION
This pull request enhances the user experience on the `DashboardMap` component by improving how device information is displayed in map popups. Now, when a marker represents only a single device, the popup provides detailed information about that device, including its status, TMAT value, last update time, and a clearer message if data is unavailable.

**Improvements to device popups in `DashboardMap`:**

* Added a detailed popup for single-device markers, displaying device ID, location, status, TMAT value, last update time, and a message for missing data. This ensures users get more relevant and actionable information when clicking on individual devices.
* Refactored the popup rendering logic to use a conditional (`? :`) instead of a logical AND (`&&`), allowing for distinct content between single-device and multi-device markers.…mation in Popup for single devices