### PR TITLE
Add toggle for daily summary in DeviceAnalyticsPanel

### DIFF
--- a/components/DeviceAnalyticsPanel.tsx
+++ b/components/DeviceAnalyticsPanel.tsx
@@ -33,6 +33,7 @@ const DeviceAnalyticsPanel: React.FC<Props> = ({ selectedDevice, realtimeData, o
   const { data: perusahaanList } = usePerusahaan(user?.perusahaanId || undefined);
   const { data: realtimeSnapshotData } = useRealtimeAll(user?.perusahaanId || undefined);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isDailySummaryOpen, setIsDailySummaryOpen] = useState(false);
   const [historicalData, setHistoricalData] = useState<RealtimeData[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<Error | null>(null);
@@ -458,12 +459,25 @@ const DeviceAnalyticsPanel: React.FC<Props> = ({ selectedDevice, realtimeData, o
 
             {/* Daily Rainfall and Humidity Summary */}
             <div className="bg-white rounded-lg border border-slate-200 p-4">
-              <h4 className="text-xs font-bold text-slate-700 mb-3 flex items-center gap-2">
-                <CloudRain size={14} className="text-blue-600" />
-                {t('dashboard:analytics.dailySummary')}
-              </h4>
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <h4 className="text-xs font-bold text-slate-700 flex items-center gap-2">
+                  <CloudRain size={14} className="text-blue-600" />
+                  {t('dashboard:analytics.dailySummary')}
+                </h4>
+                <button
+                  type="button"
+                  onClick={() => setIsDailySummaryOpen((prev) => !prev)}
+                  className="text-slate-500 hover:text-slate-700 transition-colors"
+                  aria-label={isDailySummaryOpen ? 'Close Ringkasan Harian' : 'Open Ringkasan Harian'}
+                >
+                  <ChevronUp
+                    size={16}
+                    className={`transition-transform ${isDailySummaryOpen ? '' : 'rotate-180'}`}
+                  />
+                </button>
+              </div>
 
-              {dailySummaryData.length > 0 ? (
+              {isDailySummaryOpen && (dailySummaryData.length > 0 ? (
                 <div className="space-y-3">
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                     <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
@@ -513,7 +527,7 @@ const DeviceAnalyticsPanel: React.FC<Props> = ({ selectedDevice, realtimeData, o
                 </div>
               ) : (
                 <p className="text-xs text-slate-500">{t('dashboard:analytics.noHistoricalData')}</p>
-              )}
+              ))}
             </div>
 
             {/* Tabbed Chart Section */}


### PR DESCRIPTION
This pull request improves the usability of the daily rainfall and humidity summary section in the `DeviceAnalyticsPanel` by adding a toggle for expanding and collapsing the summary. The main changes are focused on UI/UX enhancements for better user interaction.

**UI/UX Improvements:**

* Added a new state variable `isDailySummaryOpen` to control the visibility of the daily summary section, allowing users to expand or collapse the content.
* Replaced the static header with a header that includes a toggle button (with a chevron icon) to expand/collapse the daily summary section. The button updates its aria-label for accessibility and rotates the chevron icon based on the open/closed state.
* The daily summary data is now conditionally rendered only when the section is expanded, improving performance and reducing visual clutter.