### PR TITLE
Add debug logging for device filtering and chart data aggregation

### DIFF
--- a/pages/FullMap.tsx
+++ b/pages/FullMap.tsx
@@ -152,14 +152,47 @@ const FullMap: React.FC = () => {
     filteredDevices.length > 0 && !!filters.startDate && !!filters.endDate
   );
 
+  // DEBUG: Log data flow
+  useEffect(() => {
+    console.log('[FullMap] Public Devices:', {
+      count: publicDevices?.length || 0,
+      aktifCount: publicDevices?.filter(d => d.status === 'aktif').length || 0,
+      sample: publicDevices?.[0],
+    });
+  }, [publicDevices]);
+
+  useEffect(() => {
+    console.log('[FullMap] Filtered Devices:', {
+      count: filteredDevices.length,
+      sample: filteredDevices[0],
+    });
+  }, [filteredDevices]);
+
+  useEffect(() => {
+    console.log('[FullMap] Historical Data:', {
+      recordCount: historicalData.data?.length || 0,
+      isLoading: historicalData.isLoading,
+      error: historicalData.error?.message,
+      sample: historicalData.data?.[0],
+      dateRange: `${filters.startDate} to ${filters.endDate}`,
+    });
+  }, [historicalData.data, historicalData.isLoading, historicalData.error, filters.startDate, filters.endDate]);
+
   const chartData = useMemo(() => {
-    return buildTmatChartSeries(
+    const result = buildTmatChartSeries(
       historicalData.data,
       filteredDevices,
       filters.startDate,
       filters.endDate,
       filters.selectedCity
     );
+    console.log('[FullMap] Chart Data Result:', {
+      daily: result.daily.length,
+      weekly: result.weekly.length,
+      trend: result.trend.length,
+      dailySample: result.daily?.[0],
+    });
+    return result;
   }, [filters.endDate, filters.selectedCity, filters.startDate, filteredDevices, historicalData.data]);
 
   useEffect(() => {

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -115,7 +115,7 @@ function normalizePublicMapDevice(raw: any): PublicMapDevice {
     kode_titik: raw.kode_titik ?? null,
     latitude: Number(raw.latitude),
     longitude: Number(raw.longitude),
-    status: raw.status || 'nonaktif',
+    status: raw.status || 'aktif', // Public devices default to 'aktif' for chart aggregation
     tipe_alat: raw.tipe_alat ?? null,
     provinsi_id: raw.provinsi_id ?? null,
     provinsi_nama: raw.provinsi_nama ?? null,

--- a/utils/tmatChartAggregation.ts
+++ b/utils/tmatChartAggregation.ts
@@ -89,11 +89,25 @@ export function buildTmatChartSeries(
   selectedCity?: string | null
 ): TmatChartSeries {
   if (!historicalData.length || !devices.length) {
+    console.log('[buildTmatChartSeries] Early exit:', {
+      dataLength: historicalData.length,
+      deviceLength: devices.length,
+    });
     return { daily: [], weekly: [], trend: [] };
   }
 
   const deviceIds = devices.map((device) => device.device_id_unik);
+  console.log('[buildTmatChartSeries] Initial:', {
+    inputDeviceCount: devices.length,
+    inputDataCount: historicalData.length,
+    deviceIds: deviceIds.slice(0, 3),
+  });
+
   let relevantData = historicalData.filter((record) => deviceIds.includes(record.device_id_unik));
+  console.log('[buildTmatChartSeries] After device ID filter:', {
+    matchingRecordCount: relevantData.length,
+    sampleRecord: relevantData[0],
+  });
 
   let applicableDevices = devices;
   if (selectedCity) {
@@ -101,10 +115,22 @@ export function buildTmatChartSeries(
     applicableDevices = cityDevices;
     const cityDeviceIds = cityDevices.map((device) => device.device_id_unik);
     relevantData = relevantData.filter((record) => cityDeviceIds.includes(record.device_id_unik));
+    console.log('[buildTmatChartSeries] After city filter:', {
+      cityDeviceCount: cityDevices.length,
+      matchingRecordCount: relevantData.length,
+    });
   }
 
   const aktifDevices = applicableDevices.filter((device) => device.status === 'aktif');
   const aktifDeviceIds = aktifDevices.map((device) => device.device_id_unik);
+  console.log('[buildTmatChartSeries] Aktif devices:', {
+    totalDevices: applicableDevices.length,
+    aktifCount: aktifDevices.length,
+    statusDistribution: applicableDevices.reduce((acc, d) => {
+      acc[d.status || 'undefined'] = (acc[d.status || 'undefined'] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>),
+  });
 
   if (startDate || endDate) {
     relevantData = relevantData.filter((record) => {
@@ -114,9 +140,24 @@ export function buildTmatChartSeries(
       const matchesEnd = !endDate || dataDate <= endDate;
       return matchesStart && matchesEnd;
     });
+    console.log('[buildTmatChartSeries] After date filter:', {
+      startDate,
+      endDate,
+      matchingRecordCount: relevantData.length,
+    });
   }
 
   relevantData = relevantData.filter((record) => aktifDeviceIds.includes(record.device_id_unik));
+  console.log('[buildTmatChartSeries] After aktif filter:', {
+    matchingRecordCount: relevantData.length,
+    recordsPerDevice: Array.from(
+      relevantData.reduce((acc, r) => {
+        acc.set(r.device_id_unik, (acc.get(r.device_id_unik) || 0) + 1);
+        return acc;
+      }, new Map<string, number>()),
+      ([id, count]) => ({ id, count })
+    ),
+  });
 
   const dailyAggregation: Record<string, TmatChartDailyPoint> = {};
   const latestDailyByDevice = new Map<string, RealtimeData>();
@@ -149,6 +190,11 @@ export function buildTmatChartSeries(
   });
 
   const daily = Object.values(dailyAggregation).sort((a, b) => a.date.localeCompare(b.date));
+  console.log('[buildTmatChartSeries] Daily aggregation:', {
+    dateCount: daily.length,
+    aktifDeviceIds: aktifDeviceIds,
+    sample: daily[0],
+  });
 
   const weeklyAggregation: Record<string, TmatChartWeeklyPoint> = {};
   const latestWeeklyByDevice = new Map<string, RealtimeData>();
@@ -193,6 +239,12 @@ export function buildTmatChartSeries(
       time: extractTimePart(record.timestamp_data) || String(record.timestamp_data || ''),
       tmat: record.tmat_value,
     }));
+
+  console.log('[buildTmatChartSeries] Final result:', {
+    dailyCount: daily.length,
+    weeklyCount: weekly.length,
+    trendCount: trend.length,
+  });
 
   return { daily, weekly, trend };
 }


### PR DESCRIPTION
This pull request introduces extensive debugging and logging statements throughout the data aggregation and chart-building flow for the public device map. The primary goal is to make it easier to trace data as it passes through filtering, aggregation, and chart preparation steps, as well as to clarify the handling of device status defaults.

Key changes include:

**Debugging and Logging Enhancements:**

* Added multiple `console.log` statements in `FullMap.tsx` to log the state and flow of `publicDevices`, `filteredDevices`, `historicalData`, and the chart data result at various points in the React component lifecycle.
* Inserted detailed logging at each major step of the `buildTmatChartSeries` function in `tmatChartAggregation.ts` to trace input sizes, filtering stages (device, city, date, status), and aggregation results for daily, weekly, and trend data. [[1]](diffhunk://#diff-edc7359e61cc7b91b2b7cb39e59f423d12c252348206bd436c99663d7f3d62f0R92-R133) [[2]](diffhunk://#diff-edc7359e61cc7b91b2b7cb39e59f423d12c252348206bd436c99663d7f3d62f0R143-R160) [[3]](diffhunk://#diff-edc7359e61cc7b91b2b7cb39e59f423d12c252348206bd436c99663d7f3d62f0R193-R197) [[4]](diffhunk://#diff-edc7359e61cc7b91b2b7cb39e59f423d12c252348206bd436c99663d7f3d62f0R243-R248)

**Device Status Handling:**

* Changed the default status for public devices in `normalizePublicMapDevice` (in `apiClient.ts`) from `'nonaktif'` to `'aktif'` to ensure correct aggregation in charts when the status is missing.…on in FullMap and tmatChartAggregation