### PR TITLE
Enhance FullMap and APIClient with email and role filters

### DIFF
--- a/pages/FullMap.tsx
+++ b/pages/FullMap.tsx
@@ -1,8 +1,10 @@
-﻿import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import DashboardMap from '../components/DashboardMap';
 import ChartContainer from '../components/charts/ChartContainer';
 import { useHistoricalDataAllChunks, usePublicMapDevices, usePublicMapSummary } from '../services/useApi';
+import { PublicMapDeviceFilters } from '../services/apiClient';
 import { useFilters } from '../context/FilterContext';
 import { Device } from '../types';
 import { buildTmatChartSeries } from '../utils/tmatChartAggregation';
@@ -18,6 +20,7 @@ const normalizeRegionValue = (value?: string | null): string => {
 
 const FullMap: React.FC = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const { filters, updateFilter } = useFilters();
   const [chartView, setChartView] = useState<'daily' | 'weekly'>('daily');
   const publicFilterInitializedRef = useRef(false);
@@ -37,13 +40,38 @@ const FullMap: React.FC = () => {
     window.location.hash.startsWith('#/map/')
   );
 
-  const publicLocationFilters = useMemo(() => ({
-    provinsi: filters.provinsi || '',
-    kabupaten: filters.kabupaten || '',
-    kecamatan: filters.kecamatan || '',
-    desa: filters.desa || '',
-    jenis_perusahaan: filters.jenis_perusahaan || '',
-  }), [filters.provinsi, filters.kabupaten, filters.kecamatan, filters.desa, filters.jenis_perusahaan]);
+  const mapScopeFromQuery = useMemo((): Pick<PublicMapDeviceFilters, 'email' | 'role'> | null => {
+    const hashQuery = typeof window !== 'undefined' ? window.location.hash.split('?')[1] || '' : '';
+    const queryInput = location.search || hashQuery;
+    const query = new URLSearchParams(queryInput.startsWith('?') ? queryInput : '?' + queryInput);
+    const email = (query.get('email') || '').trim();
+    const roleParam = (query.get('role') || '').trim().toLowerCase();
+
+    if (!email || !roleParam) {
+      return null;
+    }
+
+    if (roleParam !== 'admin' && roleParam !== 'perusahaan' && roleParam !== 'pemda') {
+      return null;
+    }
+
+    return { email, role: roleParam };
+  }, [location.search]);
+
+  const publicLocationFilters = useMemo((): PublicMapDeviceFilters | null => {
+    if (!mapScopeFromQuery) {
+      return null;
+    }
+
+    return {
+      ...mapScopeFromQuery,
+      provinsi: filters.provinsi || '',
+      kabupaten: filters.kabupaten || '',
+      kecamatan: filters.kecamatan || '',
+      desa: filters.desa || '',
+      jenis_perusahaan: filters.jenis_perusahaan || '',
+    };
+  }, [mapScopeFromQuery, filters.provinsi, filters.kabupaten, filters.kecamatan, filters.desa, filters.jenis_perusahaan]);
 
   const {
     data: publicSummary,
@@ -220,6 +248,19 @@ const FullMap: React.FC = () => {
 
   const isLoading = summaryLoading || devicesLoading || historicalData.isLoading;
   const hasError = summaryError || devicesError || historicalData.error;
+
+  if (!mapScopeFromQuery) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
+        <div className="bg-white border border-amber-200 rounded-xl p-6 shadow-sm space-y-2 max-w-lg">
+          <h3 className="font-bold text-amber-800">Parameter map tidak valid</h3>
+          <p className="text-amber-700">
+            Gunakan format URL `#/map?email=user@email.com&role=admin|perusahaan|pemda`.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -16,6 +16,16 @@ export interface PaginatedResponse<T> {
   limit: number;
 }
 
+export interface PublicMapDeviceFilters {
+  email: string;
+  role: 'admin' | 'perusahaan' | 'pemda';
+  provinsi?: string;
+  kabupaten?: string;
+  kecamatan?: string;
+  desa?: string;
+  jenis_perusahaan?: string;
+}
+
 export function getApiHost() {
   return getApiBaseUrl(getCurrentApiMode());
 }
@@ -304,10 +314,12 @@ export class APIClient {
     return this.request<PublicMapSummary>('/public/map/summary');
   }
 
-  async getPublicMapDevices(filters: Record<string, string>): Promise<PublicMapDevice[]> {
+  async getPublicMapDevices(filters: PublicMapDeviceFilters): Promise<PublicMapDevice[]> {
     const params = new URLSearchParams();
     Object.entries(filters).forEach(([key, value]) => {
-      if (value) params.set(key, value);
+      if (typeof value === 'string' && value.trim()) {
+        params.set(key, value);
+      }
     });
     const query = params.toString();
     const response = await this.request<any>(`/public/map/devices${query ? `?${query}` : ''}`);

--- a/services/useApi.ts
+++ b/services/useApi.ts
@@ -5,7 +5,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getAPIClient, APIClient } from './apiClient';
+import { getAPIClient, APIClient, PublicMapDeviceFilters } from './apiClient';
 import { Device, Perusahaan, PublicMapAnalytics, PublicMapDevice, PublicMapSummary, RealtimeData } from '../types';
 import { splitDateRangeIntoChunks, DateChunk } from '../utils/dateChunking';
 
@@ -211,13 +211,17 @@ export function usePublicMapSummary() {
   };
 }
 
-export function usePublicMapDevices(filters: Record<string, string>) {
+export function usePublicMapDevices(filters: PublicMapDeviceFilters | null) {
   const query = useQuery({
     queryKey: ['public-map-devices', filters],
     queryFn: async () => {
+      if (!filters) {
+        return [];
+      }
       const client = getAPIClient();
       return client.getPublicMapDevices(filters);
     },
+    enabled: !!filters,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
   });


### PR DESCRIPTION
This pull request updates the `FullMap` page and related API logic to add robust support for filtering map data based on URL query parameters for `email` and `role`. It introduces a new `PublicMapDeviceFilters` type, validates query parameters, and improves error handling for invalid URLs. The main changes are grouped below:

**Filtering and Validation Enhancements:**

* Added parsing and validation for `email` and `role` parameters from the URL query string in `FullMap.tsx`, ensuring only valid roles (`admin`, `perusahaan`, `pemda`) are accepted. If missing or invalid, a user-friendly error message is displayed. [[1]](diffhunk://#diff-c164d05d398605178e6292de29f2d5db0fa29262269e1a9c31955acef7899aedL40-R74) [[2]](diffhunk://#diff-c164d05d398605178e6292de29f2d5db0fa29262269e1a9c31955acef7899aedR252-R264)
* Introduced the `PublicMapDeviceFilters` interface to standardize filter parameters used for public map device queries.

**API and Hook Updates:**

* Updated the `APIClient.getPublicMapDevices` method to accept a `PublicMapDeviceFilters` object and improved parameter handling to skip empty values.
* Modified the `usePublicMapDevices` hook to accept a `PublicMapDeviceFilters | null` argument and return an empty array if filters are not provided, preventing unnecessary API calls.

**Dependency and Import Adjustments:**

* Updated imports in `FullMap.tsx` and `useApi.ts` to include the new filter type and necessary hooks for query parameter access. [[1]](diffhunk://#diff-c164d05d398605178e6292de29f2d5db0fa29262269e1a9c31955acef7899aedL1-R7) [[2]](diffhunk://#diff-134df7280e86cfffa0a6d2a049b7089ffdd80c8751f24b53b8eba34e29a53bd5L8-R8)… for public map devices